### PR TITLE
Should fix the remote request thingy

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,26 @@ class SteamAuth {
 
   // Authenticate user
   async authenticate(req) {
+    // FIXME: Hotfix 06/18/2023
+    // More info: https://twitter.com/variancewarren/status/1670405889113702400
+    const OPENID_CHECK = {
+      ns: 'http://specs.openid.net/auth/2.0',
+      claimed_id: 'https://steamcommunity.com/openid/id/',
+      identity: 'https://steamcommunity.com/openid/id/',
+    };
+
+    const searchParams = url.parse(req.url, true).query;
+
+    if (searchParams['openid.ns'] !== OPENID_CHECK.ns) return reject("Claimed identity is not valid.");
+    if (!searchParams['openid.claimed_id']?.startsWith(OPENID_CHECK.claimed_id)) return reject("Claimed identity is not valid.");
+    if (!searchParams['openid.identity']?.startsWith(OPENID_CHECK.identity)) return reject("Claimed identity is not valid.");
+
+    const validOpEndpoint = 'https://steamcommunity.com/openid/login';
+          
+    if(searchParams['openid.op_endpoint'] !== validOpEndpoint) {
+      throw new Error("Claimed identity is not valid.");
+    }
+    
     return new Promise((resolve, reject) => {
       // Verify assertion
       this.relyingParty.verifyAssertion(req, async (error, result) => {
@@ -99,26 +119,6 @@ class SteamAuth {
           return reject("Claimed identity is not valid.");
 
         try {
-          // FIXME: Hotfix 06/18/2023
-          // More info: https://twitter.com/variancewarren/status/1670405889113702400
-          const OPENID_CHECK = {
-            ns: 'http://specs.openid.net/auth/2.0',
-            claimed_id: 'https://steamcommunity.com/openid/id/',
-            identity: 'https://steamcommunity.com/openid/id/',
-          };
-
-          const searchParams = url.parse(req.url, true).query;
-
-          if (searchParams['openid.ns'] !== OPENID_CHECK.ns) return reject("Claimed identity is not valid.");
-          if (!searchParams['openid.claimed_id']?.startsWith(OPENID_CHECK.claimed_id)) return reject("Claimed identity is not valid.");
-          if (!searchParams['openid.identity']?.startsWith(OPENID_CHECK.identity)) return reject("Claimed identity is not valid.");
-
-          const validOpEndpoint = 'https://steamcommunity.com/openid/login';
-          
-          if(searchParams['openid.op_endpoint'] !== validOpEndpoint) {
-            return reject("Claimed identity is not valid.");
-          } 
-
           const user = await this.fetchIdentifier(result.claimedIdentifier);
 
           return resolve(user);


### PR DESCRIPTION
You need to check query before calling `verifyAssertion`, otherwise `openid` does its thingy.